### PR TITLE
fix case sensitive problem

### DIFF
--- a/priv/repo/migrations/20161025011946_alter_email_index.exs
+++ b/priv/repo/migrations/20161025011946_alter_email_index.exs
@@ -1,0 +1,10 @@
+defmodule PhoenixChina.Repo.Migrations.AlterEmailIndex do
+  use Ecto.Migration
+
+  def change do
+    # 移除旧索引
+    drop index(:users, [:email])
+    # 增加新索引
+    create unique_index(:users, ["lower(email)"])
+  end
+end

--- a/web/models/user.ex
+++ b/web/models/user.ex
@@ -46,7 +46,7 @@ defmodule PhoenixChina.User do
     |> cast(params, [:email, :password, :username, :luotest_response])
     |> validate_required([:email, :password, :username], message: "不能为空")
     |> validate_format(:email, ~r/@/, message: "请输入正确的邮箱地址")
-    |> unique_constraint(:email, message: "邮箱已被注册啦！")
+    |> unique_constraint(:email, name: :users_lower_email_index, message: "邮箱已被注册啦！")
     |> validate_length(:password, min: 6, max: 128)
     |> validate_exclusion(:username, ~w(admin, superadmin), message: "不允许使用的用户名")
     |> validate_format(:username, ~r/^[a-zA-Z][\w\.\-]{3,17}$/, message: "只允许字母开头，由字母、数字、\"_\"、\".\"、\"-\"组成，4-18位。")


### PR DESCRIPTION
`a@b.com` 和 `A@b.com` 应当认为重复。PostgreSQL 默认大小写敏感，会当它们不重复。

如果生产环境中已经有重复数据，`mix ecto.migrate` 应该会报错。我因为在开发环境下跑，所以直接重置了数据库。